### PR TITLE
39 use configfile instead of buddy exporter config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 
 FROM golang:1.20-alpine
 
-MAINTAINER Pavel Strobl "mail@pubel.dev"
-
 WORKDIR /app
 
 COPY go.mod ./

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ I also prepared a configuration for on-premise Prometheus and Loki if you do not
 
 #### prusa.yml
 
-Prusa exporter loads [prusa.yml](docs/examples/config/prusa.yml) from an environment variable called `$PRUSA_EXPORTER_CONFIG`. If you put this file in the same folder where prusa exporter is located then simply set it to `prusa.yml`. Prusa exporter has implemented a config reloader that runs by default every 300 seconds (5 minutes).
+Prusa exporter loads [prusa.yml](docs/examples/config/prusa.yml) from an command flag `--config.file=<path>`. This flag can be empty and if so exporter will just try to load `prusa.yml` file located in the executable folder. Prusa exporter has implemented a config reloader that runs by default every 300 seconds (5 minutes).
 
 You will find two sections in the config file, `exporter` and `printers`.
 

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -80,7 +81,9 @@ func loadConfigFile() {
 }
 
 func getConfigPath() string {
-	cfgFile := os.Getenv("PRUSA_EXPORTER_CONFIG")
+	var cfgFile string
+	flag.StringVar(&cfgFile, "config.file", "", "Path to prusa.yml config file") // later will use flag.Args
+	flag.Parse()
 	if cfgFile == "" {
 		pwd, e := os.Getwd()
 		if e != nil {

--- a/docker-compose.on_premise.yaml
+++ b/docker-compose.on_premise.yaml
@@ -63,6 +63,7 @@ services:
         target: /app/prusa.yml
     ports:
       - "10009:10009"
+    command: '--config.file=/app/prusa.yml'
     networks:
       - prusa
 

--- a/docker-compose.rpi-cloud.yaml
+++ b/docker-compose.rpi-cloud.yaml
@@ -14,6 +14,7 @@ services:
         target: /app/prusa.yml
     ports:
       - "10009:10009"
+    command: '--config.file=/app/prusa.yml'
     networks:
       - prusa
   agent:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,22 +49,19 @@ services:
     volumes:
       - ./docs/examples/config/on_premise/promtail.yaml:/etc/promtail/config.yml
       - /var/log:/var/log
-    command: -config.file=/etc/promtail/config.yml
+    command: '--config.file=/etc/promtail/config.yml'
     networks:
       - prusa
 
   exporter:
     image: pubeldev/prusa_exporter:latest
     container_name: exporter
-    environment:
-      - PRUSA_EXPORTER_PORT=10009
-      - PRUSA_EXPORTER_SCRAPE_TIMEOUT=1
-      #- PRUSA_EXPORTER_CONFIG=/etc/prusa_exporter/prusa.yml
     volumes:
       - type: bind
         source: ./docs/examples/config/on_premise/prusa.yml
         target: /app/prusa.yml
     ports:
       - "10009:10009"
+    command: '--config.file=/app/prusa.yml'
     networks:
       - prusa


### PR DESCRIPTION
From now the exporter uses --config.file=<path> to read the path to the `prusa.yml` file.