### PR TITLE
feature implemented for buddy boards

### DIFF
--- a/config.go
+++ b/config.go
@@ -112,6 +112,14 @@ func probeConfigFile(parsedConfig configuration) configuration {
 	for i, s := range parsedConfig.Printers.Buddy {
 		if testConnection(s.Address) {
 			parsedConfig.Printers.Buddy[i].Reachable = true
+			_, _, _, _, _, info, _, err := getBuddyResponse(s)
+			if err == nil {
+				if info.Hostname == "" {
+					parsedConfig.Printers.Buddy[i].Type = "unknown"
+				} else {
+					parsedConfig.Printers.Buddy[i].Type = info.Hostname
+				}
+			}
 		} else {
 			parsedConfig.Printers.Buddy[i].Reachable = false
 			log.Error().Msg(s.Address + " is not reachable")

--- a/docs/examples/config/grafana_cloud/prusa.yml
+++ b/docs/examples/config/grafana_cloud/prusa.yml
@@ -6,12 +6,10 @@ exporter:
 printers:
   buddy:
   - address: <address_of_printer>
-    username: maker # I'm not aware that there is posibility to change user name in XL or MK4 printers - default is maker
+    username: maker 
     pass: <password>
     name: <your_printer_name>
-    type: <mk4 or xl>
   - address: <address_of_printer>
-    username: maker # I'm not aware that there is posibility to change user name in XL or MK4 printers - default is maker
+    username: maker
     pass: <password>
     name: <your_printer_name>
-    type: <mk4 or xl>


### PR DESCRIPTION
Updated config file and configuration loading so it can detect printer type if it's online. For offline printers it does not work. Works only for Buddy boards, einsy is for now postponed.