### PR TITLE
Apply metric name conventions

### DIFF
--- a/prusalink/prometheus.go
+++ b/prusalink/prometheus.go
@@ -51,39 +51,39 @@ func NewCollector(config config.Config) *Collector {
 	configuration = config
 	defaultLabels := []string{"printer_address", "printer_model", "printer_name", "printer_job_name", "printer_job_path"}
 	return &Collector{
-		printerBedTemp:            prometheus.NewDesc("prusa_bed_temp", "Current temp of printer bed in Celsius", defaultLabels, nil),
+		printerBedTemp:            prometheus.NewDesc("prusa_bed_temperature_celsius", "Current temp of printer bed in Celsius", defaultLabels, nil),
 		printerPrintSpeed:         prometheus.NewDesc("prusa_print_speed_ratio", "Current setting of printer speed in ratio (0.0-1.0)", defaultLabels, nil),
-		printerFiles:              prometheus.NewDesc("prusa_files", "Number of files in storage", append(defaultLabels, "printer_storage"), nil),
-		printerPrintTimeRemaining: prometheus.NewDesc("prusa_printing_time_remaining", "Returns time that remains for completion of current print", defaultLabels, nil),
+		printerFiles:              prometheus.NewDesc("prusa_files_count", "Number of files in storage", append(defaultLabels, "printer_storage"), nil),
+		printerPrintTimeRemaining: prometheus.NewDesc("prusa_printing_time_remaining_seconds", "Returns time that remains for completion of current print", defaultLabels, nil),
 		printerPrintProgress:      prometheus.NewDesc("prusa_printing_progress", "Returns information about completion of current print in percents", defaultLabels, nil),
-		printerMaterial:           prometheus.NewDesc("prusa_material", "Returns information about loaded filament. Returns 0 if there is no loaded filament", append(defaultLabels, "printer_filament"), nil),
-		printerPrintTime:          prometheus.NewDesc("prusa_print_time", "Returns information about current print time.", defaultLabels, nil),
+		printerMaterial:           prometheus.NewDesc("prusa_material_info", "Returns information about loaded filament. Returns 0 if there is no loaded filament", append(defaultLabels, "printer_filament"), nil),
+		printerPrintTime:          prometheus.NewDesc("prusa_print_time_seconds", "Returns information about current print time.", defaultLabels, nil),
 		printerUp:                 prometheus.NewDesc("prusa_up", "Return information about online printers. If printer is registered as offline then returned value is 0.", []string{"printer_address", "printer_model", "printer_name"}, nil),
-		printerNozzleSize:         prometheus.NewDesc("prusa_nozzle_size", "Returns information about selected nozzle size.", defaultLabels, nil),
-		printerStatus:             prometheus.NewDesc("prusa_status", "Returns information status of printer.", append(defaultLabels, "printer_state"), nil),
+		printerNozzleSize:         prometheus.NewDesc("prusa_nozzle_size_meters", "Returns information about selected nozzle size.", defaultLabels, nil),
+		printerStatus:             prometheus.NewDesc("prusa_status_info", "Returns information status of printer.", append(defaultLabels, "printer_state"), nil),
 		printerAxis:               prometheus.NewDesc("prusa_axis", "Returns information about position of axis.", append(defaultLabels, "printer_axis"), nil),
 		printerFlow:               prometheus.NewDesc("prusa_print_flow_ratio", "Returns information about of filament flow in ratio (0.0 - 1.0).", defaultLabels, nil),
 		printerInfo:               prometheus.NewDesc("prusa_info", "Returns information about printer.", append(defaultLabels, "api_version", "server_version", "version_text", "prusalink_name", "printer_location", "serial_number", "printer_hostname"), nil),
 		printerMMU:                prometheus.NewDesc("prusa_mmu", "Returns information if MMU is enabled.", defaultLabels, nil),
-		printerFanSpeed:           prometheus.NewDesc("prusa_fan_speed", "Returns information about speed of hotend fan in rpm.", append(defaultLabels, "fan"), nil),
+		printerFanSpeed:           prometheus.NewDesc("prusa_fan_speed_rpm", "Returns information about speed of hotend fan in rpm.", append(defaultLabels, "fan"), nil),
 		printerPrintSpeedRatio:    prometheus.NewDesc("prusa_print_speed_ratio", "Current setting of printer speed in values from 0.0 - 1.0", []string{"printer_address", "printer_model", "printer_name", "printer_job_name", "printer_job_path"}, nil),
 		printerLogs:               prometheus.NewDesc("prusa_logs", "Return size of logs in Prusa Link", []string{"printer_address", "printer_model", "printer_name", "printer_job_name", "printer_job_path", "log_name"}, nil),
 		printerLogsDate:           prometheus.NewDesc("prusa_logs_date", "Return date of logs in Prusa Link", []string{"printer_address", "printer_model", "printer_name", "printer_job_name", "printer_job_path", "log_name"}, nil),
 		printerFarmMode:           prometheus.NewDesc("prusa_farm_mode", "Return if printer is set to farm mode", []string{"printer_address", "printer_model", "printer_name", "printer_job_name", "printer_job_path"}, nil),
-		printerCameras:            prometheus.NewDesc("prusa_cameras", "Return information about cameras", []string{"printer_address", "printer_model", "printer_name", "printer_job_name", "printer_job_path", "camera_id", "camera_name", "camera_resolution"}, nil),
-		printerCover:              prometheus.NewDesc("prusa_cover", "Status of the printer - 0 = open, 1 = closed", defaultLabels, nil),
-		printerAmbientTemp:        prometheus.NewDesc("prusa_ambient_temp", "Status of the printer ambient temp", defaultLabels, nil),
-		printerCPUTemp:            prometheus.NewDesc("prusa_cpu_temp", "Status of the printer cpu temp", defaultLabels, nil),
-		pritnerUVTemp:             prometheus.NewDesc("prusa_uv_temp", "Status of the printer uv temp", defaultLabels, nil),
-		printerBedTempTarget:      prometheus.NewDesc("prusa_bed_temp_target", "Target bed temp", defaultLabels, nil),
-		printerBedTempOffset:      prometheus.NewDesc("prusa_bed_temp_offset", "Offset bed temp", defaultLabels, nil),
-		printerChamberTemp:        prometheus.NewDesc("prusa_chamber_temp", "Status of the printer chamber temp", defaultLabels, nil),
-		printerChamberTempTarget:  prometheus.NewDesc("prusa_chamber_temp_target", "Traget chamber temp", defaultLabels, nil),
-		printerChamberTempOffset:  prometheus.NewDesc("prusa_chamber_temp_offset", "Offset chamber temp", defaultLabels, nil),
-		printerToolTemp:           prometheus.NewDesc("prusa_tool_temp", "Status of the printer tool temp", append(defaultLabels, "tool"), nil),
-		printerToolTempTarget:     prometheus.NewDesc("prusa_tool_temp_target", "Target tool temp", append(defaultLabels, "tool"), nil),
-		printerToolTempOffset:     prometheus.NewDesc("prusa_tool_temp_offset", "Offset tool temp", append(defaultLabels, "tool"), nil),
-		printerHeatedChamber:      prometheus.NewDesc("prusa_heated_chamber", "Status of the printer heated chamber", defaultLabels, nil),
+		printerCameras:            prometheus.NewDesc("prusa_cameras_info", "Return information about cameras", []string{"printer_address", "printer_model", "printer_name", "printer_job_name", "printer_job_path", "camera_id", "camera_name", "camera_resolution"}, nil),
+		printerCover:              prometheus.NewDesc("prusa_cover_status", "Status of the printer - 0 = open, 1 = closed", defaultLabels, nil),
+		printerAmbientTemp:        prometheus.NewDesc("prusa_ambient_temperature_celsius", "Status of the printer ambient temp", defaultLabels, nil),
+		printerCPUTemp:            prometheus.NewDesc("prusa_cpu_temperature_celsius", "Status of the printer cpu temp", defaultLabels, nil),
+		pritnerUVTemp:             prometheus.NewDesc("prusa_uv_temperature_celsius", "Status of the printer uv temp", defaultLabels, nil),
+		printerBedTempTarget:      prometheus.NewDesc("prusa_bed_target_temperature_celsius", "Target bed temp", defaultLabels, nil),
+		printerBedTempOffset:      prometheus.NewDesc("prusa_bed_offset_temperature_celsius", "Offset bed temp", defaultLabels, nil),
+		printerChamberTemp:        prometheus.NewDesc("prusa_chamber_temperature_celsius", "Status of the printer chamber temp", defaultLabels, nil),
+		printerChamberTempTarget:  prometheus.NewDesc("prusa_chamber_target_temperature_celsius", "Traget chamber temp", defaultLabels, nil),
+		printerChamberTempOffset:  prometheus.NewDesc("prusa_chamber_offset_temperature_celsius", "Offset chamber temp", defaultLabels, nil),
+		printerToolTemp:           prometheus.NewDesc("prusa_tool_temperature_celsius", "Status of the printer tool temp", append(defaultLabels, "tool"), nil),
+		printerToolTempTarget:     prometheus.NewDesc("prusa_tool_target_temperature_celsius", "Target tool temp", append(defaultLabels, "tool"), nil),
+		printerToolTempOffset:     prometheus.NewDesc("prusa_tool_offset_temperature_celsius", "Offset tool temp", append(defaultLabels, "tool"), nil),
+		printerHeatedChamber:      prometheus.NewDesc("prusa_heated_chamber_info", "Status of the printer heated chamber", defaultLabels, nil),
 	}
 }
 
@@ -249,7 +249,7 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 				ch <- printerFanPrint
 
 				printerNozzleSize := prometheus.MustNewConstMetric(collector.printerNozzleSize, prometheus.GaugeValue,
-					info.NozzleDiameter, GetLabels(s, job)...)
+					info.NozzleDiameter/1000, GetLabels(s, job)...)
 
 				ch <- printerNozzleSize
 


### PR DESCRIPTION
See https://prometheus.io/docs/practices/naming/

While some might seem extreme (nozzle_size_meters), Grafana unit handling makes things easy. And having the unit in the name helps a lot when building complex queries.

cc @richih would love your review here as well!