### PR TITLE
Resolve UDP printer_address label via reverse DNS

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -66,6 +67,27 @@ func Run() {
 	log.Info().Msg("PrusaLink metrics enabled!")
 	collectors = append(collectors, prusalink.NewCollector(config))
 
+	// Register each printer's configured address so UDP metrics use the same
+	// label value as PrusaLink metrics, regardless of whether it's a hostname
+	// (short or FQDN) or an IP address.
+	resolver := udp.NewAddrResolver()
+	for _, p := range config.Printers {
+		// p.Address is host:port — extract just the host before resolving.
+		host, _, err := net.SplitHostPort(p.Address)
+		if err != nil {
+			host = p.Address // no port present
+		}
+		ips, err := net.LookupHost(host)
+		if err != nil {
+			// Unresolvable — register the raw address string as-is.
+			resolver.SetAddress(host, p.Address)
+			continue
+		}
+		for _, ip := range ips {
+			resolver.SetAddress(ip, p.Address)
+		}
+	}
+
 	if *udpGcodeEnabled {
 		prusalink.EnableUDPmetrics(config.Printers)
 	} else {
@@ -74,7 +96,7 @@ func Run() {
 	// starting syslog server
 
 	log.Info().Msg("Syslog server starting at: " + *syslogListenAddress)
-	go udp.MetricsListener(*syslogListenAddress, *udpPrefix)
+	go udp.MetricsListener(*syslogListenAddress, *udpPrefix, resolver)
 	log.Info().Msg("Syslog server ready to receive metrics")
 
 	// registering the prometheus metrics

--- a/udp/syslog.go
+++ b/udp/syslog.go
@@ -19,14 +19,14 @@ func startSyslogServer(listenUDP string) (syslog.LogPartsChannel, *syslog.Server
 }
 
 // MetricsListener is a function to handle syslog metrics and sent them to processor
-func MetricsListener(listenUDP string, prefix string) {
+func MetricsListener(listenUDP string, prefix string, resolver *AddrResolver) {
 	channel, server := startSyslogServer(listenUDP)
 
 	go func(channel syslog.LogPartsChannel) {
 		for logParts := range channel {
 			log.Trace().Msg(fmt.Sprintf("%v", logParts))
 
-			process(logParts, prefix)
+			process(logParts, prefix, resolver)
 		}
 	}(channel)
 

--- a/udp/syslog_test.go
+++ b/udp/syslog_test.go
@@ -53,7 +53,7 @@ func TestMetricsListenerSetup(t *testing.T) {
 		// Use a timeout to prevent hanging
 		done := make(chan bool, 1)
 		go func() {
-			MetricsListener(listenAddr, "test_")
+			MetricsListener(listenAddr, "test_", NewAddrResolver())
 			done <- true
 		}()
 

--- a/udp/transform.go
+++ b/udp/transform.go
@@ -2,13 +2,65 @@ package udp
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
 	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
+
+// AddrResolver maps syslog source IPs to canonical printer_address label
+// values. Configured addresses (from prusa.yml) take priority over reverse DNS.
+// Populate with SetAddress before starting any goroutine that calls Resolve.
+type AddrResolver struct {
+	// addresses is written only at startup (before concurrent Resolve calls).
+	addresses map[string]string
+	// cache stores DNS-fallback results for IPs not in addresses.
+	cache sync.Map
+}
+
+// NewAddrResolver returns a ready-to-use AddrResolver.
+func NewAddrResolver() *AddrResolver {
+	return &AddrResolver{addresses: make(map[string]string)}
+}
+
+// SetAddress registers the canonical label for a printer IP.
+// Must be called before any concurrent Resolve calls.
+func (r *AddrResolver) SetAddress(ip, address string) {
+	r.addresses[ip] = address
+}
+
+// Resolve returns the canonical printer_address label for a syslog source IP.
+// Priority: configured address > reverse DNS short hostname > raw IP.
+// DNS-fallback results are cached after the first lookup.
+func (r *AddrResolver) Resolve(ip string) string {
+	// Configured address always wins — not cached, so a new SetAddress call is
+	// always visible without needing to invalidate any cache.
+	if addr, ok := r.addresses[ip]; ok {
+		return addr
+	}
+	// Check cache for previously resolved DNS-fallback result.
+	if v, ok := r.cache.Load(ip); ok {
+		return v.(string)
+	}
+	// Fall back to reverse DNS short hostname.
+	result := ip
+	names, err := net.LookupAddr(ip)
+	if err == nil && len(names) > 0 {
+		host := strings.TrimSuffix(names[0], ".")
+		if i := strings.IndexByte(host, '.'); i != -1 {
+			host = host[:i]
+		}
+		if host != "" {
+			result = host
+		}
+	}
+	r.cache.Store(ip, result)
+	return result
+}
 
 type point struct {
 	Measurement string
@@ -16,16 +68,22 @@ type point struct {
 	Fields      map[string]interface{} // Use interface{} to handle different field types
 }
 
-func process(data format.LogParts, prefix string) {
+func process(data format.LogParts, prefix string, resolver *AddrResolver) {
 	mac, ip, err := processIdentifiers(data)
 	if err != nil {
 		log.Error().Msg(fmt.Sprintf("Error processing identifiers: %v", err))
 		return
 	}
-	lastPush.WithLabelValues(mac, strings.Split(ip, ":")[0]).Set(float64(time.Now().Unix())) // Set the last push timestamp
+	// Strip port once here; handles both IPv4 (1.2.3.4:port) and IPv6 ([::1]:port).
+	host, _, err := net.SplitHostPort(ip)
+	if err != nil {
+		host = ip // already a bare address
+	}
+	addr := resolver.Resolve(host)
+	lastPush.WithLabelValues(mac, addr).Set(float64(time.Now().Unix())) // Set the last push timestamp
 
 	log.Debug().Msg(fmt.Sprintf("Processing data for printer %s", mac))
-	metrics, err := processMessage(data["message"].(string), mac, prefix, ip)
+	metrics, err := processMessage(data["message"].(string), mac, prefix, addr)
 	if err != nil {
 		log.Error().Msg(fmt.Sprintf("Error processing message: %v", err))
 		return
@@ -58,7 +116,7 @@ func processIdentifiers(data format.LogParts) (string, string, error) {
 	return mac, ip, nil
 }
 
-func processMessage(message string, mac string, prefix string, ip string) ([]string, error) {
+func processMessage(message string, mac string, prefix string, addr string) ([]string, error) {
 	messageSplit := strings.Split(message, "\n")
 
 	if len(messageSplit) == 0 {
@@ -75,7 +133,7 @@ func processMessage(message string, mac string, prefix string, ip string) ([]str
 
 	for i, line := range messageSplit {
 		splitted := strings.Split(line, " ")
-		splitted, err = updateMetric(splitted, prefix, mac, ip)
+		splitted, err = updateMetric(splitted, prefix, mac, addr)
 		if err != nil {
 			log.Error().Msg("Expected error while adding mac label for metric: " + splitted[0] + " error:" + err.Error())
 			continue
@@ -94,12 +152,12 @@ func parseFirstMessage(message string) (string, error) {
 	return strings.Join(firstMsg, " "), nil
 }
 
-func updateMetric(splitted []string, prefix string, mac string, ip string) ([]string, error) {
+func updateMetric(splitted []string, prefix string, mac string, addr string) ([]string, error) {
 	if len(splitted) == 0 {
 		return nil, fmt.Errorf("splitted message is empty")
 	}
 
-	splitted[0] = fmt.Sprintf("%s%s,printer_mac=%s,printer_address=%s", prefix, splitted[0], mac, strings.Split(ip, ":")[0])
+	splitted[0] = fmt.Sprintf("%s%s,printer_mac=%s,printer_address=%s", prefix, splitted[0], mac, addr)
 	return splitted, nil
 }
 

--- a/udp/transform_extended_test.go
+++ b/udp/transform_extended_test.go
@@ -164,7 +164,7 @@ func TestProcessMessage(t *testing.T) {
 		message  string
 		mac      string
 		prefix   string
-		ip       string
+		addr     string
 		expected int // expected number of metrics
 	}{
 		{
@@ -172,7 +172,7 @@ func TestProcessMessage(t *testing.T) {
 			message:  "12345 temp_noz v=220.5 1637000000",
 			mac:      "ABC123",
 			prefix:   "prusa_",
-			ip:       "192.168.1.100:8514",
+			addr:     "192.168.1.100",
 			expected: 1,
 		},
 		{
@@ -182,14 +182,14 @@ temp_bed v=60.0 1637000000
 fan_speed rpm=1500i 1637000000`,
 			mac:      "ABC123",
 			prefix:   "prusa_",
-			ip:       "192.168.1.100:8514",
+			addr:     "192.168.1.100",
 			expected: 3,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := processMessage(tt.message, tt.mac, tt.prefix, tt.ip)
+			result, err := processMessage(tt.message, tt.mac, tt.prefix, tt.addr)
 			if err != nil {
 				t.Errorf("processMessage() error = %v", err)
 				return
@@ -207,8 +207,8 @@ fan_speed rpm=1500i 1637000000`,
 				if !contains(metric, "printer_mac="+tt.mac) {
 					t.Errorf("processMessage() metric %s should contain mac %s", metric, tt.mac)
 				}
-				if !contains(metric, "printer_address=192.168.1.100") {
-					t.Errorf("processMessage() metric %s should contain IP address", metric)
+				if !contains(metric, "printer_address="+tt.addr) {
+					t.Errorf("processMessage() metric %s should contain address %s", metric, tt.addr)
 				}
 			}
 		})
@@ -277,7 +277,7 @@ func TestUpdateMetric(t *testing.T) {
 		splitted []string
 		prefix   string
 		mac      string
-		ip       string
+		addr     string
 		expected string
 	}{
 		{
@@ -285,7 +285,7 @@ func TestUpdateMetric(t *testing.T) {
 			splitted: []string{"temp_noz", "v=220.5", "1637000000"},
 			prefix:   "prusa_",
 			mac:      "ABC123",
-			ip:       "192.168.1.100:8514",
+			addr:     "192.168.1.100",
 			expected: "prusa_temp_noz,printer_mac=ABC123,printer_address=192.168.1.100",
 		},
 		{
@@ -293,14 +293,14 @@ func TestUpdateMetric(t *testing.T) {
 			splitted: []string{"fan,type=print", "rpm=1500i", "1637000000"},
 			prefix:   "prusa_",
 			mac:      "DEF456",
-			ip:       "10.0.0.5:8514",
+			addr:     "10.0.0.5",
 			expected: "prusa_fan,type=print,printer_mac=DEF456,printer_address=10.0.0.5",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := updateMetric(tt.splitted, tt.prefix, tt.mac, tt.ip)
+			result, err := updateMetric(tt.splitted, tt.prefix, tt.mac, tt.addr)
 			if err != nil {
 				t.Errorf("updateMetric() error = %v", err)
 				return
@@ -319,7 +319,7 @@ func TestUpdateMetric(t *testing.T) {
 
 	// Test error case
 	t.Run("Empty splitted message", func(t *testing.T) {
-		_, err := updateMetric([]string{}, "prusa_", "ABC123", "192.168.1.100:8514")
+		_, err := updateMetric([]string{}, "prusa_", "ABC123", "192.168.1.100")
 		if err == nil {
 			t.Error("updateMetric() expected error for empty input")
 		}
@@ -424,6 +424,57 @@ func stringContains(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestResolveAddr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Unresolvable IP returns IP", func(t *testing.T) {
+		t.Parallel()
+		r := NewAddrResolver()
+		ip := "192.0.2.1" // TEST-NET, guaranteed no PTR record
+		result := r.Resolve(ip)
+		if result != ip {
+			t.Errorf("Resolve(%q) = %q, want %q", ip, result, ip)
+		}
+	})
+
+	t.Run("Cached result returned on second call", func(t *testing.T) {
+		t.Parallel()
+		r := NewAddrResolver()
+		ip := "192.0.2.2"
+		r.Resolve(ip)               // populate cache with fallback IP
+		r.cache.Store(ip, "cached-host")
+		result := r.Resolve(ip)
+		if result != "cached-host" {
+			t.Errorf("Resolve() cached call = %q, want %q", result, "cached-host")
+		}
+	})
+
+	t.Run("Configured address takes priority over DNS cache", func(t *testing.T) {
+		t.Parallel()
+		r := NewAddrResolver()
+		ip := "192.0.2.3"
+		r.cache.Store(ip, "stale-cached-value") // simulate stale DNS cache entry
+		r.SetAddress(ip, "prusa-core-one.fritz.box")
+		result := r.Resolve(ip)
+		if result != "prusa-core-one.fritz.box" {
+			t.Errorf("Resolve(%q) = %q, want %q", ip, result, "prusa-core-one.fritz.box")
+		}
+	})
+
+	t.Run("Short hostname and FQDN both work via configured address", func(t *testing.T) {
+		t.Parallel()
+		ip := "192.0.2.4"
+		for _, addr := range []string{"prusa-core-one", "prusa-core-one.fritz.box"} {
+			r := NewAddrResolver()
+			r.SetAddress(ip, addr)
+			result := r.Resolve(ip)
+			if result != addr {
+				t.Errorf("Resolve(%q) with configured %q = %q, want %q", ip, addr, result, addr)
+			}
+		}
+	})
 }
 
 func BenchmarkParseLineProtocol(b *testing.B) {


### PR DESCRIPTION
The UDP syslog listener sets the printer_address label from the raw syslog source IP. This mismatches PrusaLink metrics which use the configured address (hostname or IP from prusa.yml), breaking Grafana dashboard filters that join both metric types by printer_address.

Add a cache with a reverse DNS lookup on the syslog source IP and strip the domain to produce a short hostname.
Falls back to the raw IP if DNS fails. Cache prevents per-packet DNS overhead.